### PR TITLE
Add max allowed swap percentage to filter out some small pools

### DIFF
--- a/.changeset/lazy-pigs-greet.md
+++ b/.changeset/lazy-pigs-greet.md
@@ -1,0 +1,5 @@
+---
+"@thalalabs/router-sdk": minor
+---
+
+Add max allowed swap percentage to filter out some small pools

--- a/packages/thalaswap-router/src/PoolDataClient.ts
+++ b/packages/thalaswap-router/src/PoolDataClient.ts
@@ -4,7 +4,7 @@ import { uniq } from "lodash";
 import { fp64ToFloat, parsePoolMetadata, scaleDown } from "./utils";
 
 class PoolDataClient {
-  private poolData: PoolData | null = null;
+  public poolData: PoolData | null = null;
   private lastUpdated: number = 0;
   private expiry = 10000; // 10 seconds
   private retryLimit = 3;

--- a/packages/thalaswap-router/src/ThalaswapRouter.ts
+++ b/packages/thalaswap-router/src/ThalaswapRouter.ts
@@ -19,6 +19,8 @@ const encodeWeight = (weight: number, resourceAddress: string): string => {
   return `${resourceAddress}::weighted_pool::Weight_${Math.floor(weight * 100).toString()}`;
 };
 
+const DEFAULT_MAX_ALLOWED_SWAP_PERCENTAGE = 0.5;
+
 // Encode the pool type arguments for a given pool
 // If extendStableArgs is true, then the stable pool type arguments will be extended to 8 arguments (filled with additional 4 nulls)
 const encodePoolType = (
@@ -59,22 +61,29 @@ const scaleUp = (amount: number, decimals: number): number => {
   return Math.floor(amount * Math.pow(10, decimals));
 };
 
+type Options = {
+  maxAllowedSwapPercentage?: number;
+};
+
 class ThalaswapRouter {
-  private client: PoolDataClient;
+  public client: PoolDataClient;
   private graph: Graph | null = null;
   private coins: Coin[] | null = null;
   private resourceAddress: string;
   private multirouterAddress: string;
+  private options: Options;
 
   constructor(
     network: Network,
     fullnode: string,
     resourceAddress: string,
     multirouterAddress: string,
+    options?: Options,
   ) {
     this.resourceAddress = resourceAddress;
     this.multirouterAddress = multirouterAddress;
     this.client = new PoolDataClient(network, fullnode, resourceAddress);
+    this.options = options ?? {};
   }
 
   setPoolDataClient(client: PoolDataClient) {
@@ -154,6 +163,8 @@ class ThalaswapRouter {
       endToken,
       amountIn,
       maxHops,
+      this.options.maxAllowedSwapPercentage ??
+        DEFAULT_MAX_ALLOWED_SWAP_PERCENTAGE,
     );
   }
 
@@ -176,6 +187,8 @@ class ThalaswapRouter {
       endToken,
       amountOut,
       maxHops,
+      this.options.maxAllowedSwapPercentage ??
+        DEFAULT_MAX_ALLOWED_SWAP_PERCENTAGE,
     );
   }
 

--- a/packages/thalaswap-router/src/router.ts
+++ b/packages/thalaswap-router/src/router.ts
@@ -119,6 +119,7 @@ export function findRouteGivenExactInput(
   endToken: string,
   amountIn: number,
   maxHops: number,
+  maxAllowedSwapPercentage: number,
 ): Route | null {
   const tokens = Object.keys(graph);
   // distances[token][hop] is the maximum amount of token that can be received given hop number
@@ -141,6 +142,12 @@ export function findRouteGivenExactInput(
         if (fromToken === endToken || toToken === startToken) continue; // This prevents cycles
 
         if (distances[fromToken][i] === undefined) continue; // Skip unvisited nodes
+
+        if (
+          distances[fromToken][i] / edge.pool.balances[edge.fromIndex] >
+          maxAllowedSwapPercentage
+        )
+          continue;
 
         const newDistance = calcOutGivenIn(
           distances[fromToken][i]!,
@@ -228,6 +235,7 @@ export function findRouteGivenExactOutput(
   endToken: string,
   amountOut: number,
   maxHops: number,
+  maxAllowedSwapPercentage: number,
 ): Route | null {
   const tokens = Object.keys(graph);
   const distances: Distances = {};
@@ -248,6 +256,12 @@ export function findRouteGivenExactOutput(
         if (fromToken === endToken || toToken === startToken) continue; // This prevents cycles
 
         if (distances[toToken][i] === undefined) continue; // Skip unvisited nodes
+
+        if (
+          distances[toToken][i] / edge.pool.balances[edge.toIndex] >
+          maxAllowedSwapPercentage
+        )
+          continue;
 
         try {
           const newDistance = calcInGivenOut(

--- a/packages/thalaswap-router/test/router.test.ts
+++ b/packages/thalaswap-router/test/router.test.ts
@@ -24,7 +24,9 @@ const mockPoolDataClient = {
   }),
 };
 
-const router = new ThalaswapRouter(Network.MAINNET, "test", "0x123", "0x123");
+const router = new ThalaswapRouter(Network.MAINNET, "test", "0x123", "0x123", {
+  maxAllowedSwapPercentage: 1,
+});
 router.setPoolDataClient(mockPoolDataClient as any);
 
 test("Exact input 1 hop", async () => {


### PR DESCRIPTION
- Add max allowed swap percentage to filter out some small pools.
- `poolData` is changed to public, so that pools data could be retrieved from the sdk.