### PR TITLE
Fix a bug that causes some pools to be missing in the router.

### DIFF
--- a/.changeset/good-buses-confess.md
+++ b/.changeset/good-buses-confess.md
@@ -1,0 +1,5 @@
+---
+"@thalalabs/router-sdk": patch
+---
+
+Fix a bug that causes some pools to be missing in the router.

--- a/packages/thalaswap-router/src/PoolDataClient.ts
+++ b/packages/thalaswap-router/src/PoolDataClient.ts
@@ -78,6 +78,10 @@ class PoolDataClient {
 
     const resources = await this.client.getAccountResources({
       accountAddress: resourceAddress,
+      options: {
+        // the default limit is 999, the thala account has 1000+ resources
+        limit: 10000,
+      },
     });
 
     const poolResources = resources.filter(


### PR DESCRIPTION
It's because we are using a "getAccountResources" API from ts-sdk. By default it limit 999 number of returns. But our thala account has more than 999 resources.