### PR TITLE
chore: fixed broken link

### DIFF
--- a/packages/thalaswap-math/src/weightedPoolMath.ts
+++ b/packages/thalaswap-math/src/weightedPoolMath.ts
@@ -1,4 +1,4 @@
-/// Reference "Out-Given-In" section in Balancer whitepaper https://balancer.fi/whitepaper.pdf
+/// Reference "Out-Given-In" section in Balancer whitepaper https://docs.balancer.fi/whitepaper.pdf
 /// ********************************************************************************************
 /// calcOutGivenIn                                                                            //
 /// aO = tokenAmountOut                                                                       //
@@ -21,7 +21,7 @@ export function calcOutGivenInWeighted(
   return bO * (1 - Math.pow(bI / denom, wI / wO));
 }
 
-/// Reference "In-Given-Out" section in Balancer whitepaper https://balancer.fi/whitepaper.pdf
+/// Reference "In-Given-Out" section in Balancer whitepaper https://docs.balancer.fi/whitepaper.pdf
 /// ********************************************************************************************
 /// calcInGivenOut                                                                            //
 /// aI = tokenAmountIn                                                                        //


### PR DESCRIPTION
Hi! I fixed outdated links in `packages/thalaswap-math/src/weightedPoolMath.ts`. The references to the Balancer whitepaper were pointing to `https://balancer.fi/whitepaper.pdf`, and they have been updated to `https://docs.balancer.fi/whitepaper.pdf`.
