### PR TITLE
Fix typos in comments

### DIFF
--- a/packages/thalaswap-math/src/stablePoolMath.ts
+++ b/packages/thalaswap-math/src/stablePoolMath.ts
@@ -189,7 +189,7 @@ function getY(
   );
 }
 
-// see `compute_invarient` in https://github.com/ThalaLabs/thala-modules/blob/main/thalaswap_math/sources/stable_math.move
+// see `compute_invariant` in https://github.com/ThalaLabs/thala-modules/blob/main/thalaswap_math/sources/stable_math.move
 function getD(xp: number[], a: number): number {
   const n = xp.length;
 

--- a/packages/thalaswap-router/test/router.test.ts
+++ b/packages/thalaswap-router/test/router.test.ts
@@ -252,7 +252,7 @@ test("Low price impact for MOD-USDC stable pool", async () => {
 });
 
 // Below are tests for THL -> USDT
-// We have 3 posible routes:
+// We have 3 possible routes:
 // 1. THL - USDT
 // 2. THL - APT - USDT
 // 3. THL - MOD - APT - USDT


### PR DESCRIPTION


This PR fixes spelling errors in comments:
- Corrects "posible" to "possible" in router.test.ts
- Ensures consistent formatting for the compute_invariant reference in stablePoolMath.ts