### PR TITLE
Use a new router contract which compatible with both v3 and v2 pools

### DIFF
--- a/.changeset/itchy-shrimps-retire.md
+++ b/.changeset/itchy-shrimps-retire.md
@@ -2,4 +2,4 @@
 "@thalalabs/router-sdk": minor
 ---
 
-Use a new router contract for both v3 and v2 pools
+Use a new router contract which compatible with both v3 and v2 pools

--- a/.changeset/itchy-shrimps-retire.md
+++ b/.changeset/itchy-shrimps-retire.md
@@ -1,0 +1,5 @@
+---
+"@thalalabs/router-sdk": minor
+---
+
+Use a new router contract for both v3 and v2 pools

--- a/packages/thalaswap-router/README.md
+++ b/packages/thalaswap-router/README.md
@@ -22,6 +22,8 @@ const router = new ThalaswapRouter({
     "0x2ee2526b8035890ebf30510aae8891d41116d83d2b5b7d774a3bc73d2b751d61",
   multirouterAddress:
     "0x60955b957956d79bc80b096d3e41bad525dd400d8ce957cdeb05719ed1e4fc26",
+  v2RouterAddress: 
+    "0xc36ceb6d7b137cea4897d4bc82d8e4d8be5f964c4217dbc96b0ba03cc64070f4",
 });
 const fromToken = "0x1::aptos_coin::AptosCoin";
 const toToken = "0x7fd500c11216f0fe3095d0c4b8aa4d64a4e2e04f83758462f2b127255643615::thl_coin::THL";

--- a/packages/thalaswap-router/src/PoolDataClient.ts
+++ b/packages/thalaswap-router/src/PoolDataClient.ts
@@ -66,8 +66,7 @@ class PoolDataClient {
           const v2pools = await this.getV2Pools();
           const v3pools = await this.getV3Pools();
           this.poolData = {
-            pools: [...v1pools, ...v2pools],
-            poolsV3: v3pools,
+            pools: [...v1pools, ...v2pools, ...v3pools],
             coins: this.coins,
           };
           this.lastUpdated = currentTime;

--- a/packages/thalaswap-router/src/abi/v3_router.ts
+++ b/packages/thalaswap-router/src/abi/v3_router.ts
@@ -1,5 +1,5 @@
-export const V2_ROUTER_ABI = {
-  address: "0xc36ceb6d7b137cea4897d4bc82d8e4d8be5f964c4217dbc96b0ba03cc64070f4",
+export const V3_ROUTER_ABI = {
+  address: "0x1d2bd7dd7641e65a9706d4c72bea0b1aa48a41217c481c49e41b9456d7143d0a",
   name: "router",
   friends: [],
   exposed_functions: [
@@ -10,7 +10,21 @@ export const V2_ROUTER_ABI = {
       is_view: true,
       generic_type_params: [],
       params: [
-        "vector<0x1::object::Object<0xfbdb3da73efcfa742d542f152d65fc6da7b55dee864cd66475213e4be18c9d54::pool::Pool>>",
+        "vector<address>",
+        "vector<0x1::object::Object<0x1::fungible_asset::Metadata>>",
+        "0x1::object::Object<0x1::fungible_asset::Metadata>",
+        "u64",
+      ],
+      return: ["u64"],
+    },
+    {
+      name: "simulate_out_given_in",
+      visibility: "public",
+      is_entry: false,
+      is_view: true,
+      generic_type_params: [],
+      params: [
+        "vector<address>",
         "vector<0x1::object::Object<0x1::fungible_asset::Metadata>>",
         "0x1::object::Object<0x1::fungible_asset::Metadata>",
         "u64",
@@ -29,7 +43,7 @@ export const V2_ROUTER_ABI = {
       ],
       params: [
         "&signer",
-        "vector<0x1::object::Object<0xfbdb3da73efcfa742d542f152d65fc6da7b55dee864cd66475213e4be18c9d54::pool::Pool>>",
+        "vector<address>",
         "vector<0x1::object::Object<0x1::fungible_asset::Metadata>>",
         "u64",
         "0x1::object::Object<0x1::fungible_asset::Metadata>",
@@ -49,7 +63,7 @@ export const V2_ROUTER_ABI = {
       ],
       params: [
         "&signer",
-        "vector<0x1::object::Object<0xfbdb3da73efcfa742d542f152d65fc6da7b55dee864cd66475213e4be18c9d54::pool::Pool>>",
+        "vector<address>",
         "vector<0x1::object::Object<0x1::fungible_asset::Metadata>>",
         "u64",
         "0x1::object::Object<0x1::fungible_asset::Metadata>",
@@ -65,7 +79,7 @@ export const V2_ROUTER_ABI = {
       generic_type_params: [],
       params: [
         "&signer",
-        "vector<0x1::object::Object<0xfbdb3da73efcfa742d542f152d65fc6da7b55dee864cd66475213e4be18c9d54::pool::Pool>>",
+        "vector<address>",
         "vector<0x1::object::Object<0x1::fungible_asset::Metadata>>",
         "0x1::fungible_asset::FungibleAsset",
       ],
@@ -76,6 +90,7 @@ export const V2_ROUTER_ABI = {
     {
       name: "Notacoin",
       is_native: false,
+      is_event: false,
       abilities: ["key"],
       generic_type_params: [],
       fields: [

--- a/packages/thalaswap-router/src/types.ts
+++ b/packages/thalaswap-router/src/types.ts
@@ -68,7 +68,6 @@ type Pool = {
 
 type PoolData = {
   pools: Pool[]; // for v1 and v2
-  poolsV3: Pool[]; // for v3
   coins: Coin[];
 };
 

--- a/packages/thalaswap-router/test/test-pools.json
+++ b/packages/thalaswap-router/test/test-pools.json
@@ -61,7 +61,8 @@
       "asset1": 9,
       "balance0": 13008.29255679,
       "balance1": 7089.59780576,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -70,7 +71,8 @@
       "asset1": 2,
       "balance0": 2056.163873,
       "balance1": 343.08755821,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -79,7 +81,8 @@
       "asset1": 4,
       "balance0": 116253605.3264,
       "balance1": 147928165.8321,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -88,7 +91,8 @@
       "asset1": 0,
       "balance0": 34979.5108242,
       "balance1": 35724.6883114,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -97,7 +101,8 @@
       "asset1": 2,
       "balance0": 72.51205774,
       "balance1": 13.8509258,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -106,7 +111,8 @@
       "asset1": 2,
       "balance0": 0.004836,
       "balance1": 1.32766579,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -115,7 +121,8 @@
       "asset1": 2,
       "balance0": 362930.20489986,
       "balance1": 60585.67918414,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.2, 0.8],
@@ -124,7 +131,8 @@
       "asset1": 1,
       "balance0": 248734.03692406,
       "balance1": 6879670.48528901,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -133,7 +141,8 @@
       "asset1": 2,
       "balance0": 270.645707,
       "balance1": 3.7526662,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -142,7 +151,8 @@
       "asset1": 2,
       "balance0": 28.135422,
       "balance1": 0.99660011,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -151,7 +161,8 @@
       "asset1": 3,
       "balance0": 298505.588373,
       "balance1": 178.617787,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -160,7 +171,8 @@
       "asset1": 4,
       "balance0": 2156392.68306257,
       "balance1": 1718685.730877,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -169,7 +181,8 @@
       "asset1": 2,
       "balance0": 85.842312,
       "balance1": 14.31721868,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -178,7 +191,8 @@
       "asset1": 0,
       "balance0": 128039.615342,
       "balance1": 128142.51454857,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -187,7 +201,8 @@
       "asset1": 2,
       "balance0": 4.02854082,
       "balance1": 0.14138684,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -196,7 +211,8 @@
       "asset1": 5,
       "balance0": 1.001998,
       "balance1": 0.99801,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -205,7 +221,8 @@
       "asset1": 5,
       "balance0": 4.94143188,
       "balance1": 5.141924,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -214,7 +231,8 @@
       "asset1": 2,
       "balance0": 0.023479,
       "balance1": 14.64680542,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -223,7 +241,8 @@
       "asset1": 2,
       "balance0": 24.579756,
       "balance1": 4.12285236,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -232,7 +251,8 @@
       "asset1": 0,
       "balance0": 0.571745,
       "balance1": 0.52156903,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -241,7 +261,8 @@
       "asset1": 6,
       "balance0": 222295.82288,
       "balance1": 7.312754,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.2, 0.8],
@@ -250,7 +271,8 @@
       "asset1": 2,
       "balance0": 25.909589,
       "balance1": 17.38773534,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -259,7 +281,8 @@
       "asset1": 5,
       "balance0": 26.2370464,
       "balance1": 3.833277,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -268,7 +291,8 @@
       "asset1": 2,
       "balance0": 35654.3460136,
       "balance1": 859.43733753,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -277,7 +301,8 @@
       "asset1": 5,
       "balance0": 1345237.470138,
       "balance1": 1164406.178002,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     },
     {
       "weights": [0.5, 0.5],
@@ -286,7 +311,8 @@
       "asset1": 4,
       "balance0": 92.37699208,
       "balance1": 13.095411,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "weights": [0.55, 0.45],
@@ -295,7 +321,8 @@
       "asset1": 2,
       "balance0": 204.13207378,
       "balance1": 3.98294437,
-      "swapFee": 0.003
+      "swapFee": 0.003,
+      "version": 1
     },
     {
       "poolType": "Stable",
@@ -304,7 +331,8 @@
       "asset1": 4,
       "balance0": 360.03921448,
       "balance1": 23.350643,
-      "swapFee": 0.001
+      "swapFee": 0.001,
+      "version": 1
     }
   ]
 }


### PR DESCRIPTION
Previously, we added logic for v3 pools in routing, but we routed v2 and v3 pools separately. Now, we are routing them together because the new router contract is compatible with both v3 and v2 pools.